### PR TITLE
feat: Add telegraf and gnmi configurations for ch6

### DIFF
--- a/obs_stack/ch6/configs/telegraf/telegraf-01.conf.toml
+++ b/obs_stack/ch6/configs/telegraf/telegraf-01.conf.toml
@@ -1,0 +1,32 @@
+[agent]
+ hostname = "telegraf-01"
+
+
+[[inputs.snmp]]
+ agents = ["ceos-01"]
+ version = 2
+ community = "${SNMP_COMMUNITY}"
+ interval = "60s"
+ timeout = "10s"
+ retries = 3
+
+
+ [[inputs.snmp.table]]
+   name = "interface"
+
+
+   [[inputs.snmp.table.field]]
+     oid = "IF-MIB::ifDescr"
+     is_tag = true
+
+
+   [[inputs.snmp.table.field]]
+     oid = "IF-MIB::ifHCInOctets"
+
+
+   [[inputs.snmp.table.field]]
+     oid = "IF-MIB::ifHCOutOctets"
+
+
+[[outputs.file]]
+ files = ["stdout"]

--- a/obs_stack/ch6/configs/telegraf/telegraf-02.conf.toml
+++ b/obs_stack/ch6/configs/telegraf/telegraf-02.conf.toml
@@ -1,0 +1,27 @@
+[agent]
+ hostname = "telegraf-02"
+
+
+[[inputs.gnmi]]
+ addresses = ["ceos-02:50051"]
+ username = "${NETWORK_AGENT_USER}"
+ password = "${NETWORK_AGENT_PASSWORD}"
+ redial = "20s"
+
+
+ [[inputs.gnmi.subscription]]
+   name = "interface"
+   path = "/interfaces/interface/state/counters"
+   subscription_mode = "sample"
+   sample_interval = "10s"
+
+
+ [[inputs.gnmi.subscription]]
+   name = "interface"
+   path = "/interfaces/interface/state/oper-status"
+   subscription_mode = "sample"
+   sample_interval = "10s"
+
+
+[[outputs.file]]
+ files = ["stdout"]


### PR DESCRIPTION
This commit adds the necessary configurations for telegraf and gnmi in chapter 6. It includes the telegraf configuration file for telegraf-01 and telegraf-02, as well as the gnmi configuration file for telegraf-02. These configurations enable data collection from SNMP agents and gNMI subscriptions, respectively.

^^ Copilot - pretty cool :) - This configuration is the baseline for ch6 so the reader can just focus on normalization and enrichment