### PR TITLE
Update logstash codec to "rubydebug"

### DIFF
--- a/chapters/ch5-completed/logstash/logstash.cfg
+++ b/chapters/ch5-completed/logstash/logstash.cfg
@@ -10,6 +10,6 @@ input {
 output {
     # Outputs to stdout for debugging
     stdout {
-        codec => "json"
+        codec => "rubydebug"
     }
 }

--- a/chapters/ch6-completed/logstash/logstash.cfg
+++ b/chapters/ch6-completed/logstash/logstash.cfg
@@ -43,6 +43,6 @@ filter {
 output {
     # Outputs to stdout for debugging
     stdout {
-        codec => "json"
+        codec => "rubydebug"
     }
 }

--- a/chapters/ch6/logstash/logstash.cfg
+++ b/chapters/ch6/logstash/logstash.cfg
@@ -10,6 +10,6 @@ input {
 output {
     # Outputs to stdout for debugging
     stdout {
-        codec => "json"
+        codec => "rubydebug"
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     'python-dotenv>=1.0.0',
     'jmespath>=1.0.1',
     'PyYAML>=6.0.1',
-    'netmiko>=4.3.0',
+    'netmiko==4.3.0',
     'prometheus-api-client>=0.5.5',
     'prefect>=2.17.1',
     'ansible>=10.1.0',


### PR DESCRIPTION
This pull request updates the logstash codec to "rubydebug" for debugging output. The changes are made in multiple files, specifically in the `input` and `output` sections. The previous codec value of "json" is replaced with "rubydebug". This update ensures that the debugging output is in the desired format.