### PR TITLE
Fix python parsing integers in field value (ch6 script.py)

### DIFF
--- a/chapters/ch6-completed/telegraf/script.py
+++ b/chapters/ch6-completed/telegraf/script.py
@@ -70,11 +70,14 @@ def parse_line(line: str) -> dict:
             fields[key] = value[1:-1]  # String field
         elif "." in value:
             fields[key] = float(value)  # Float field
+        elif value.endswith('i'):
+                fields[key] = int(value[:-1])  # Integer field
         else:
+        # Assume it's an un-suffixed integer or some other type
             try:
-                fields[key] = int(value)  # Integer field
-            except ValueError:
-                fields[key] = value  # Fallback to string if not an int
+                fields[key] = int(value)
+            except (ValueError, TypeError):
+                fields[key] = value
 
     # Extract timestamp if present
     if len(parts) > 2:


### PR DESCRIPTION
in chapter 6, the parse_line function in script.py parse a line of InfluxDB Line Protocol and return a dictionary with the measurement, tags, fields, and optional timestamp.

This is an example of input from the inputs.mem telegraf plugin, all 3 values are integers.
`free=3653009408i,total=5368709120i,used=160890880i`

When the input string has fields with integers, the field value contains an "i" at the end. Upon parsing, the function tries to convert it to the int type

```
        else:
            try:
                fields[key] = int(value)  # Integer field
            except ValueError:
                fields[key] = value  # Fallback to string if not an int
```

This attempt fails into ValueError because of the i letter. 

This fix erase the "i" letter in the output